### PR TITLE
Support all boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Driver for pms5003 air quality sensor for micropython
 
 ## Description and features
 This driver for the [pms5003 air quality sensor](http://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf) is specifically made for micropython.
-It can be used with esp32 (tested on [esp32_loboris fork](https://github.com/loboris/MicroPython_ESP32_psRAM_LoBo)) and will not work on esp8266 as it only has one UART.
-It is completely based on uasyncio
+It should be usable on all ports that have a uart with configurable baudrate.
+It is completely based on uasyncio.
 
 The driver covers all features of the device:
 * sleep mode and wake up by pin and uart
@@ -20,7 +20,7 @@ Reset and Set pin are completely optional though. The reset pin could make sense
 
 ## Dependencies
 
-* uasyncio (Version >= 2.0)
+* uasyncio (Version 2.0) [not version 3.0 ready yet]
 
 ## How to use
 ```
@@ -35,14 +35,14 @@ class Lock:
     async def __aenter__(self):
         while True:
             if self._locked:
-                await asyncio.sleep_ms(_DEFAULT_MS)
+                await asyncio.sleep_ms(20)
             else:
                 self._locked = True
                 break
 
     async def __aexit__(self, *args):
         self._locked = False
-        await asyncio.sleep_ms(_DEFAULT_MS)
+        await asyncio.sleep_ms(20)
 
     def locked(self):
         return self._locked

--- a/pms5003.py
+++ b/pms5003.py
@@ -446,6 +446,9 @@ class PMS5003_base:
             else:
                 await self.__await_bytes(preframe_len, 100)
                 data = self._uart.read(preframe_len)
+            if len(data) is None:
+                self._debug("Read no data from uart despite having waited for data")
+                return None
             if len(data) != preframe_len and len(data) > 0:
                 self._error("Short read, expected {!s} bytes, got {!s}".format(preframe_len, len(data)))
                 return None

--- a/pms5003.py
+++ b/pms5003.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018, Kevin Köck
+# Copyright (c) 2018-2020, Kevin Köck
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,19 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-'''
-Created on 16.06.2018
-
-@author: Kevin Köck
-'''
-
 # based on circuitpython-code of adafruit: https://learn.adafruit.com/pm25-air-quality-sensor/circuitpython-code
 # and some inspiration from https://github.com/RigacciOrg/AirPi/blob/master/lib/pms5003
 
 # command responses are only processed generally but can't distinguish between different responses
 
-__updated__ = "2018-06-24"
-__version__ = "1.9.9"
+__updated__ = "2020-07-03"
+__version__ = "1.9.11"
 
 import uasyncio as asyncio
 import time
@@ -62,8 +56,8 @@ def set_debug(debug):
 
 
 class PMS5003_base:
-    def __init__(self, uart, lock, set_pin=None, reset_pin=None, interval_passive_mode=None, event=None,
-                 active_mode=True, eco_mode=True, assume_sleeping=True):
+    def __init__(self, uart, lock, set_pin=None, reset_pin=None, interval_passive_mode=None,
+                 event=None, active_mode=True, eco_mode=True, assume_sleeping=True):
         self._uart = uart  # accepts a uart object
         self._set_pin = set_pin
         if set_pin is not None:
@@ -78,7 +72,8 @@ class PMS5003_base:
         self._interval_passive_mode = interval_passive_mode or 60  # in case someone forgets to set it
         if self._eco_mode and self._active_mode is False and self._interval_passive_mode < WAIT_AFTER_WAKEUP + 5:
             self._error(
-                "interval_passive_mode can't be less than DEVICE_WAKEUP_TIME of {!s}s".format(WAIT_AFTER_WAKEUP + 5))
+                "interval_passive_mode can't be less than DEVICE_WAKEUP_TIME of {!s}s".format(
+                    WAIT_AFTER_WAKEUP + 5))
             self._interval_passive_mode = 60
         self._event = event
         self._lock = lock
@@ -108,8 +103,9 @@ class PMS5003_base:
         """Puts device to sleep between readings in passive mode"""
         self._eco_mode = value
         if self._eco_mode and self._active_mode is False and self._interval_passive_mode < WAIT_AFTER_WAKEUP + 5:
-            self._error("interval_passive_mode can't be less than DEVICE_WAKEUP_TIME of {!s}s".format(
-                WAIT_AFTER_WAKEUP + 5))
+            self._error(
+                "interval_passive_mode can't be less than DEVICE_WAKEUP_TIME of {!s}s".format(
+                    WAIT_AFTER_WAKEUP + 5))
             self._interval_passive_mode = 60
 
     async def setActiveMode(self):
@@ -147,8 +143,9 @@ class PMS5003_base:
             if interval is not None:
                 self._interval_passive_mode = interval
                 if self._eco_mode and self._active_mode is False and self._interval_passive_mode < WAIT_AFTER_WAKEUP + 5:
-                    self._error("interval_passive_mode can't be less than DEVICE_WAKEUP_TIME of {!s}s".format(
-                        WAIT_AFTER_WAKEUP + 5))
+                    self._error(
+                        "interval_passive_mode can't be less than DEVICE_WAKEUP_TIME of {!s}s".format(
+                            WAIT_AFTER_WAKEUP + 5))
                     self._interval_passive_mode = 60
             self._active_mode = False
             await asyncio.sleep_ms(100)
@@ -191,10 +188,12 @@ class PMS5003_base:
                     self._error("No response to wakeup pin change")
                     return False
             else:
-                res = await self._sendCommand(0xe4, 0x01, False, delay=16000, wait=WAIT_AFTER_WAKEUP * 1000)
+                res = await self._sendCommand(0xe4, 0x01, False, delay=16000,
+                                              wait=WAIT_AFTER_WAKEUP * 1000)
                 if res is None:
                     await asyncio.sleep_ms(100)
-                    res = await self._sendCommand(0xe4, 0x01, False, delay=16000, wait=WAIT_AFTER_WAKEUP * 1000)
+                    res = await self._sendCommand(0xe4, 0x01, False, delay=16000,
+                                                  wait=WAIT_AFTER_WAKEUP * 1000)
                     if res is None:
                         self._error("No response to wakeup command")
                         return False
@@ -228,7 +227,8 @@ class PMS5003_base:
             return False
 
     async def _sendCommand(self, command, data, expect_command=True, delay=1000, wait=None):
-        self._debug("Sending command: {!s},{!s},{!s},{!s}".format(command, data, expect_command, delay))
+        self._debug(
+            "Sending command: {!s},{!s},{!s},{!s}".format(command, data, expect_command, delay))
         arr = bytearray(7)
         arr[0] = 0x42
         arr[1] = 0x4d
@@ -286,7 +286,8 @@ class PMS5003_base:
             self._callback = [self._callback, callback]
 
     def registerEvent(self, event):
-        # enhances usability; by using an event with active mode a fast reaction to changing values is possible
+        # enhances usability; by using an event with active mode a fast reaction to
+        # changing values is possible
         self._event = event
 
     def print(self):
@@ -299,10 +300,12 @@ class PMS5003_base:
             print("---------------------------------------------")
             print("Concentration Units (standard)")
             print("---------------------------------------------")
-            print("PM 1.0: %d\tPM2.5: %d\tPM10: %d" % (self._pm10_standard, self._pm25_standard, self._pm100_standard))
+            print("PM 1.0: %d\tPM2.5: %d\tPM10: %d" % (
+            self._pm10_standard, self._pm25_standard, self._pm100_standard))
             print("Concentration Units (environmental)")
             print("---------------------------------------------")
-            print("PM 1.0: %d\tPM2.5: %d\tPM10: %d" % (self._pm10_env, self._pm25_env, self._pm100_env))
+            print("PM 1.0: %d\tPM2.5: %d\tPM10: %d" % (
+            self._pm10_env, self._pm25_env, self._pm100_env))
             print("---------------------------------------------")
             print("Particles > 0.3um / 0.1L air:", self._particles_03um)
             print("Particles > 0.5um / 0.1L air:", self._particles_05um)
@@ -367,7 +370,8 @@ class PMS5003_base:
                             if self._active and self._event is not None:
                                 self._event.set()
                             if self._active and self._callback is not None:
-                                cbs = [self._callback] if type(self._callback) != list else self._callback
+                                cbs = [self._callback] if type(
+                                    self._callback) != list else self._callback
                                 for cb in cbs:
                                     # call callback or await coroutine, should be short.
                                     tmp = cb()
@@ -377,18 +381,21 @@ class PMS5003_base:
                         counter += 1
                         await asyncio.sleep_ms(100)
             if self._active_mode:
-                await asyncio.sleep_ms(100)  # give other commands time to send and receive response (keep lock free)
+                await asyncio.sleep_ms(100)
+                # give other commands time to send and receive response (keep lock free)
                 woke_up = None
             else:
                 sleep = self._interval_passive_mode - (time.ticks_ms() - last_reading) / 1000
                 if self._eco_mode:
                     await self.sleep()
-                    sleep -= (WAIT_AFTER_WAKEUP + 1)  # +1 is experience as commands to wakeup and set mode take time
+                    sleep -= (WAIT_AFTER_WAKEUP + 1)
+                    # +1 is experience as commands to wakeup and set mode take time
                 else:
                     woke_up = None  # probably changed mode during sleep
                 if sleep < 2:  # making 2s between reading attempts the smallest interval
                     sleep = 2
-                sleep = int(sleep)  # a bit of rounding the value, a few hundred ms earlier is neede for commands
+                sleep = int(sleep)
+                # a bit of rounding the value, a few hundred ms earlier is needed for commands
                 self._debug("loop sleep for {!s}s".format(sleep))
                 await asyncio.sleep(sleep)
                 if self._sleeping_state:
@@ -450,7 +457,8 @@ class PMS5003_base:
                 self._debug("Read no data from uart despite having waited for data")
                 return None
             if len(data) != preframe_len and len(data) > 0:
-                self._error("Short read, expected {!s} bytes, got {!s}".format(preframe_len, len(data)))
+                self._error(
+                    "Short read, expected {!s} bytes, got {!s}".format(preframe_len, len(data)))
                 return None
             if data == b'':
                 return None
@@ -476,7 +484,8 @@ class PMS5003_base:
                     await self.__await_bytes(frame_len - CMD_FRAME_LENGTH, 100)
                     data = self._uart.read(frame_len - CMD_FRAME_LENGTH)
                 if len(data) != DATA_FRAME_LENGTH - CMD_FRAME_LENGTH:
-                    self._error("Short read, expected {!s} bytes, got {!s}".format(frame_len, len(data)))
+                    self._error(
+                        "Short read, expected {!s} bytes, got {!s}".format(frame_len, len(data)))
                     return None
                 buffer += list(data)
                 check = buffer[-2] * 256 + buffer[-1]
@@ -509,7 +518,8 @@ class PMS5003_base:
             elif frame_len == 0:
                 pass  # wrong frame/bytes received
             else:
-                self._warn("Unexpected frame_len {!s}, probably random or scrambled bytes".format(frame_len))
+                self._warn("Unexpected frame_len {!s}, probably random or scrambled bytes".format(
+                    frame_len))
 
             buffer = []
             continue
@@ -594,10 +604,12 @@ class PMS5003_base:
 
 
 class PMS5003(PMS5003_base):
-    def __init__(self, uart, lock, set_pin=None, reset_pin=None, interval_passive_mode=None, event=None,
-                 active_mode=True, eco_mode=True, assume_sleeping=True):
-        super().__init__(uart, lock, set_pin=set_pin, reset_pin=reset_pin, interval_passive_mode=interval_passive_mode,
-                         event=event, active_mode=active_mode, eco_mode=eco_mode, assume_sleeping=assume_sleeping)
+    def __init__(self, uart, lock, set_pin=None, reset_pin=None, interval_passive_mode=None,
+                 event=None, active_mode=True, eco_mode=True, assume_sleeping=True):
+        super().__init__(uart, lock, set_pin=set_pin, reset_pin=reset_pin,
+                         interval_passive_mode=interval_passive_mode,
+                         event=event, active_mode=active_mode, eco_mode=eco_mode,
+                         assume_sleeping=assume_sleeping)
 
     async def _makeResilient(self, *args, **kwargs):
         if "first_try" not in kwargs:
@@ -643,11 +655,13 @@ class PMS5003(PMS5003_base):
     async def setActiveMode(self):
         while self._active is True and self._sleeping_state is True:
             await asyncio.sleep_ms(100)
-            # device has to wake up first and after that we'll set the state or weird behaviour possible otherwise
+            # device has to wake up first and after that we'll set the state or
+            # weird behaviour possible otherwise
         await self._makeResilient(super().setActiveMode)
 
     async def setPassiveMode(self, interval=None):
         while self._active is True and self._sleeping_state is True:
             await asyncio.sleep_ms(100)
-            # device has to wake up first and after that we'll set the state or weird behaviour possible otherwise
+            # device has to wake up first and after that we'll set the state or
+            # weird behaviour possible otherwise
         await self._makeResilient(super().setPassiveMode, interval=interval)


### PR DESCRIPTION
Add support for all boards by using a generic method for flushing the uart rx buffer.
Device specific methods could be implemented by subclassing PMS5003.

Fixes #1 